### PR TITLE
[fix] typo

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -17,7 +17,7 @@
             'React / Vue',
             'Next / Nuxt',
             'Java',
-            'Koltin',
+            'Kotlin',
             'Swift',
             'C#',
             '.NET',


### PR DESCRIPTION
- Fixed typo where Kotlin was spelt "Koltin."